### PR TITLE
AI for Work Documentation fixups

### DIFF
--- a/docs/agent-platform/ai-agents/ai-for-work.md
+++ b/docs/agent-platform/ai-agents/ai-for-work.md
@@ -2,19 +2,19 @@
 
 AI for Work is an enterprise platform that integrates AI to optimize productivity. It unifies information access, automates workflows, and enhances knowledge work. This addresses information fragmentation, manual inefficiencies, and AI accessibility, leading to improved operational efficiency and allowing employees to focus on high-value tasks.
 
-The Platform offers comprehensive end-to-end development, deployment, and advanced multi-agent orchestration for scalable Agentic applications at the enterprise level. It works seamlessly with AI for Work, allowing organizations to quickly deploy intelligent service solutions that leverage conversation optimization and multi-agent orchestration. This integration enhances customer satisfaction and reduces operational costs.
+The Agent Platform offers comprehensive end-to-end development, deployment, and advanced multi-agent orchestration for scalable Agentic applications at the enterprise level. It works seamlessly with AI for Work, allowing organizations to quickly deploy intelligent service solutions that leverage conversation optimization and multi-agent orchestration. This integration enhances customer satisfaction and reduces operational costs.
 
 ## Prerequisites
 
-* AI for Work and the Platform applications must exist in the same workspace.
+* AI for Work and the Agent Platform applications must exist in the same workspace.
 * You must have administrator access to AI for Work.
 
 ## Create Workflow Agents and Autonomous Agents in AI for Work
 
-Powered by the Platform, AI for Work enables the development of two distinct agent types: Workflow Agents and Autonomous Agents.
+Powered by the Agent Platform, AI for Work enables the development of two distinct agent types: Workflow Agents and Autonomous Agents.
 
 ## Agent Types
 
-**Workflow Agent:** Workflow Agents in AI for Work leverage capabilities from the Platform to deliver precise, contextually relevant responses to user queries in real-time. This streamlined approach simplifies the creation of intelligent agents, enabling the rapid deployment of business solutions. <a href="https://docs.kore.ai/ai-for-work/custom-agents/workflow-agents/" target="_blank">Learn more about Workflow Agents.</a>
+**Workflow Agent:** Workflow Agents in AI for Work leverage capabilities from the Agent Platform to deliver precise, contextually relevant responses to user queries in real-time. This streamlined approach simplifies the creation of intelligent agents, enabling the rapid deployment of business solutions. <a href="https://docs.kore.ai/ai-for-work/custom-agents/workflow-agents/" target="_blank">Learn more about Workflow Agents.</a>
 
-**Autonomous Agent:** Autonomous Agents leverage the Platform to manage complex business tasks and workflows independently. These AI-powered agents utilize adaptive algorithms for dynamic decision-making, responding to evolving business requirements in real-time. <a href="https://docs.kore.ai/ai-for-work/custom-agents/autonomous-agent/" target="_blank">Learn more about Autonomous Agents.</a>
+**Autonomous Agent:** Autonomous Agents leverage the Agent Platform to manage complex business tasks and workflows independently. These AI-powered agents utilize adaptive algorithms for dynamic decision-making, responding to evolving business requirements in real-time. <a href="https://docs.kore.ai/ai-for-work/custom-agents/autonomous-agent/" target="_blank">Learn more about Autonomous Agents.</a>

--- a/docs/ai-for-work/custom-agents/work-agent.md
+++ b/docs/ai-for-work/custom-agents/work-agent.md
@@ -113,7 +113,7 @@ The Data Assistant agent requires access to all configured tools. Open its confi
 
 With your application configured, you'll create a deployable version and establish an environment for production use. The versioning system allows you to maintain multiple configurations and roll back if needed.
 
-1. Go to **Deployment** → **Versions** → **Create Version**.
+1. Go to **Deployment** → **Versions** → **New Version**.
 2. Save the version to capture your current configuration.
 <img src="../images/work-agent-version.png" alt="work-agent-version" title="work-agent-version" style="border: 1px solid gray; zoom:70%;">
 
@@ -128,7 +128,7 @@ With your application configured, you'll create a deployable version and establi
 Create the API credentials that the Platform uses to communicate with your deployment.
 
 1. Copy the **deployment cURL** from your environment.
-2. Go to **API Scoping** → **Create Scope**.
+2. Go to **API Scopes** → **New API Scope**.
 <img src="../images/work-agent-api-scope.png" alt="work-agent-api-scope" title="work-agent-api-scope" style="border: 1px solid gray; zoom:70%;">
 
 3. Navigate to **API Keys → Create Key** using your scope.


### PR DESCRIPTION
A couple small changes:

- While going through the AI for Work documentation involving agent integration for agents in the Agent Platform, I noticed a couple small discrepancies between the documentation and what's actually present in the platform (screenshots are from Agent Platform):

   - “Create Version” -> “New Version” ([source](https://docs.kore.ai/ai-for-work/custom-agents/work-agent/#create-and-deploy-version))
<img width="1504" height="113" alt="app_versions___new_version" src="https://github.com/user-attachments/assets/eafcf674-d96a-42dc-8eae-ba1913b77058" />

   - “API Scoping” -> “API Scopes”, “Create Scope” -> “New API Scope” ([source](https://docs.kore.ai/ai-for-work/custom-agents/work-agent/#generate-api-credentials))
<img width="1503" height="112" alt="api_scopes___create_new_scope" src="https://github.com/user-attachments/assets/e8031ef7-f011-49be-81d9-4e34283e2f56" />

- I  also clarified that "the Platform" mentioned in the ["AI for Work with Agent Platform"](https://docs.kore.ai/agent-platform/ai-agents/ai-for-work/#ai-for-work-with-agent-platform) page is specifically referring to "the Agent Platform", since that page talks about both the AI for Work Platform and the Agent Platform and when I initially read it, "the Platform" was a little ambiguous
